### PR TITLE
MNT: Add python_min version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "jupytergis-packages" %}
 {% set version = "0.2.0" %}
+{% set python_min = "3.8" %}
 
 package:
   name: {{ name|lower }}
@@ -21,7 +22,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
 
 
 outputs:


### PR DESCRIPTION
For [`v0.2.0` the `requires-python` is `>=3.8`](https://github.com/geojupyter/jupytergis/blob/86abebbeb76bf8f9fa4e61797a45c12a6b14a904/python/jupytergis/pyproject.toml#L30) but PR #6 enforces the conda-forge distribution to require Python 3.9+. This results in a mismatch of support between PyPI and conda-forge which is not desirable. If you manually set `python_min` to be the lower bound of the supported Python from the upstream/PyPI distribution it will automatically enforce the correct support matching moving forward (in that the build will fail if an automated update has a newer `requires-python`, ensuring that the version in the conda-forge recipe gets updated correctly).

* Set python_min explicitly to match the upstream project requires-python of `>=3.8.`
   - Setting python_min explicitly has additional benefits such as effectively checking that the Python version metadata is being enforced. c.f. https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-python
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
