### PR TITLE
Convert to v1 recipe, bump python_min to 3.12, resolve missing libqca-qt5 shared lib

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,63 +23,84 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
-            UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
     steps:
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Configure binfmt_misc
+      if: matrix.os == 'ubuntu'
+      shell: bash
+      run: |
+        if [[ "$(uname -m)" == "x86_64" ]]; then
+          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
+        fi
 
     - name: Build on Linux
       id: build-linux
       if: matrix.os == 'ubuntu'
       env:
-        CONFIG: ${{ matrix.CONFIG }}
-        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
-        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
         CI: github_actions
-        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.CONDA_FORGE_DOCKER_RUN_ARGS }}"
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONDA_FORGE_DOCKER_RUN_ARGS: ${{ matrix.docker_run_args }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
+        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
-        if [[ "$(uname -m)" == "x86_64" ]]; then
-          echo "::group::Configure binfmt_misc"
-          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
-        fi
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
           export IS_PR_BUILD="False"
         fi
-        echo "::endgroup::"
         ./.scripts/run_docker_build.sh
 
     - name: Build on macOS
       id: build-macos
       if: matrix.os == 'macos'
       env:
-        CONFIG: ${{ matrix.CONFIG }}
-        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         CI: github_actions
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
@@ -97,14 +118,14 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
-        # default value; make it explicit, as it needs to match with artefact
-        # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
-        MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
-        PYTHONUNBUFFERED: 1
-        CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        PYTHONUNBUFFERED: 1
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -36,7 +36,7 @@ mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-
 echo > /opt/conda/conda-meta/history
 micromamba install --root-prefix ~/.conda --prefix /opt/conda \
     --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip  rattler-build conda-forge-ci-setup=4 "conda-build>=26.3"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -58,20 +58,37 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    # differences between conda-build vs. rattler-build
+    #   - 1 step (conda debug + manually open shell) vs. 2 step (rb debug {setup, shell})
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --output-id vs. --output-name
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${FEEDSTOCK_ROOT}/build_artifacts}"
+    rattler-build debug setup \
+        --recipe "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+        ${BUILD_OUTPUT_ID:+--output-name "${BUILD_OUTPUT_ID}"} \
+        --target-platform "${HOST_PLATFORM}"
 
-    # Drop into an interactive shell
-    /bin/bash
+    rattler-build debug shell
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+    # differences between conda-build vs. rattler-build
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --suppress-variables vs. none
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    #   - --extra-meta a=b c=d vs. --extra-meta a=b --extra-meta c=d
+
+    rattler-build build \
+        --recipe "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --target-platform "${HOST_PLATFORM}" \
+        --extra-meta flow_run_id="${flow_run_id:-}" \
+        --extra-meta remote_url="${remote_url:-}" \
+        --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -96,6 +96,14 @@ if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
     fi
 fi
 
+# When running on GitHub Actions, mount the step summary file into the container
+# and point GITHUB_STEP_SUMMARY at it so that rattler-build's GitHub integration
+# can write its summary. GitHub writes the file out to the job summary after the
+# step finishes.
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} -v ${GITHUB_STEP_SUMMARY}:/home/conda/github_step_summary:rw${VOLUME_SUFFIX},delegated -e GITHUB_STEP_SUMMARY=/home/conda/github_step_summary"
+fi
+
 ( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
@@ -107,17 +115,20 @@ ${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
 ${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
-           -e CONFIG \
-           -e HOST_USER_ID \
-           -e UPLOAD_PACKAGES \
-           -e IS_PR_BUILD \
-           -e GIT_BRANCH \
-           -e UPLOAD_ON_BRANCH \
-           -e CI \
-           -e FEEDSTOCK_NAME \
-           -e CPU_COUNT \
-           -e BUILD_WITH_CONDA_DEBUG \
            -e BUILD_OUTPUT_ID \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e CI \
+           -e CONFIG \
+           -e CPU_COUNT \
+           -e FEEDSTOCK_NAME \
+           -e GIT_BRANCH \
+           -e GITHUB_ACTIONS \
+           -e HOST_USER_ID \
+           -e IS_PR_BUILD \
+           -e RATTLER_BUILD_COLOR \
+           -e RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION \
+           -e UPLOAD_ON_BRANCH \
+           -e UPLOAD_PACKAGES \
            -e flow_run_id \
            -e remote_url \
            -e sha \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About jupytergis-packages-feedstock
-===================================
+About jupytergis-feedstock
+==========================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/jupytergis-packages-feedstock/blob/main/LICENSE.txt)
 
@@ -16,7 +16,6 @@ Documentation: https://jupytergis.readthedocs.io/en/latest
 jupytergis is a JupyterLab extension for GIS with collaborative editing support. It is designed to allow multiple people to work on the same file at the same time, and to facilitate discussion and collaboration around the GIS visualization being created.
 jupytergis has support for QGIS files, which makes it easy to import and export models from QGIS. It also has a range of features for creating and manipulating layers.
 
-
 Current build status
 ====================
 
@@ -24,7 +23,9 @@ Current build status
 <table><tr>
     <td>All platforms:</td>
     <td>
-      <img src="https://img.shields.io/badge/noarch-disabled-lightgrey.svg" alt="noarch disabled">
+      <a href="https://github.com/conda-forge/jupytergis-packages-feedstock/actions/workflows/conda-build.yml">
+        <img src="https://github.com/conda-forge/jupytergis-packages-feedstock/actions/workflows/conda-build.yml/badge.svg?event=push&branch=main">
+      </a>
     </td>
   </tr>
 </table>
@@ -40,10 +41,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-jupytergis--lite-green.svg)](https://anaconda.org/conda-forge/jupytergis-lite) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jupytergis-lite.svg)](https://anaconda.org/conda-forge/jupytergis-lite) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jupytergis-lite.svg)](https://anaconda.org/conda-forge/jupytergis-lite) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jupytergis-lite.svg)](https://anaconda.org/conda-forge/jupytergis-lite) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-jupytergis--qgis-green.svg)](https://anaconda.org/conda-forge/jupytergis-qgis) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jupytergis-qgis.svg)](https://anaconda.org/conda-forge/jupytergis-qgis) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jupytergis-qgis.svg)](https://anaconda.org/conda-forge/jupytergis-qgis) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jupytergis-qgis.svg)](https://anaconda.org/conda-forge/jupytergis-qgis) |
 
-Installing jupytergis-packages
-==============================
+Installing jupytergis
+=====================
 
-Installing `jupytergis-packages` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `jupytergis` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -129,17 +130,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating jupytergis-packages-feedstock
-======================================
+Updating jupytergis-feedstock
+=============================
 
-If you would like to improve the jupytergis-packages recipe or build a new
+If you would like to improve the jupytergis recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/jupytergis-packages-feedstock are
+Note that all branches in the conda-forge/jupytergis-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.

--- a/build-locally.py
+++ b/build-locally.py
@@ -98,7 +98,10 @@ def main(args=None):
     p.add_argument(
         "--debug",
         action="store_true",
-        help="Setup debug environment using `conda debug`",
+        help=(
+            "Setup debug environment using `conda debug` "
+            "(or `rattler-build debug` for rattler-build recipes)"
+        ),
     )
     p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,5 @@
+conda_build_tool: rattler-build
 github:
   branch_name: main
   tooling_branch_name: main
-conda_build:
-  error_overlinking: true
 conda_forge_output_validation: true

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   version: "0.15.0"
-  build_number: 0
+  build_number: 1
   python_min: "3.10"
 
 recipe:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,36 +1,38 @@
-{% set name = "jupytergis-packages" %}
-{% set version = "0.15.0" %}
-{% set python_min = "3.10" %}
+schema_version: 1
 
-package:
-  name: {{ name|lower }}
-  version: {{ version }}
+context:
+  version: "0.15.0"
+  build_number: 0
+  python_min: "3.10"
+
+recipe:
+  name: jupytergis-packages
+  version: ${{ version }}
 
 source:
-  - url: https://pypi.org/packages/source/j/jupytergis_core/jupytergis_core-{{ version }}.tar.gz
+  - url: https://pypi.org/packages/source/j/jupytergis_core/jupytergis_core-${{ version }}.tar.gz
     sha256: 57fee2717ec3605a254b8e5902a679378aff4c6861ee109ec2c0e234d8267b22
-    folder: jupytergis_core
-  - url: https://pypi.org/packages/source/j/jupytergis_lab/jupytergis_lab-{{ version }}.tar.gz
+    target_directory: jupytergis_core
+  - url: https://pypi.org/packages/source/j/jupytergis_lab/jupytergis_lab-${{ version }}.tar.gz
     sha256: e8571f972d5280b5b776c46962a9504c387967324a484383dc4870efdc70aa3a
-    folder: jupytergis_lab
-  - url: https://pypi.org/packages/source/j/jupytergis_qgis/jupytergis_qgis-{{ version }}.tar.gz
+    target_directory: jupytergis_lab
+  - url: https://pypi.org/packages/source/j/jupytergis_qgis/jupytergis_qgis-${{ version }}.tar.gz
     sha256: e480d3178f503117b096d58f5549b8b17021231a12f90f19d48f2bad0e398311
-    folder: jupytergis_qgis
-  - url: https://pypi.org/packages/source/j/jupytergis_lite/jupytergis_lite-{{ version }}.tar.gz
+    target_directory: jupytergis_qgis
+  - url: https://pypi.org/packages/source/j/jupytergis_lite/jupytergis_lite-${{ version }}.tar.gz
     sha256: c0d74a248a8230d53fbe97d17606dccacb852e783a3c06c902ead50460f1e4b5
-    folder: jupytergis_lite
-  - url: https://pypi.org/packages/source/j/jupytergis/jupytergis-{{ version }}.tar.gz
+    target_directory: jupytergis_lite
+  - url: https://pypi.org/packages/source/j/jupytergis/jupytergis-${{ version }}.tar.gz
     sha256: c6d6a90b1b1d70b5364a3950205a2c75f6873982ceaa256ab1a1d47e24a497b8
-    folder: jupytergis
+    target_directory: jupytergis
 
 build:
   noarch: python
-  number: 0
-
+  number: ${{ build_number }}
 
 outputs:
-  - name: jupytergis-core
-    version: {{ version }}
+  - package:
+      name: jupytergis-core
     build:
       noarch: python
       script: |
@@ -39,29 +41,28 @@ outputs:
     requirements:
       host:
         - pip
-        - python {{ python_min }}
+        - python ${{ python_min }}
         - hatchling
         - yarn
         - jupyterlab >=4.5.1
         - hatch-jupyter-builder
         - hatch-nodejs-version >=0.3.2
       run:
-        - python >={{ python_min }}
+        - python >=${{ python_min }}
         - jupyter_ydoc >=2,<4
-      run_constrained:
+      run_constraints:
         - jupyterlab >=4.5.1
-    test:
-      # imports:
-      #   - jupytergis_core
-      commands:
-        - pip check
-        - test -f ${PREFIX}/share/jupyter/labextensions/@jupytergis/jupytergis-core/package.json                            # [unix]
-        - if not exist %PREFIX%\\share\\jupyter\\labextensions\\@jupytergis/jupytergis-core\\package.json (exit 1)          # [win]
-      requires:
-        - pip
+    tests:
+      - python:
+          imports:
+            - jupytergis_core
+          pip_check: true
+      - package_contents:
+          files:
+            - share/jupyter/labextensions/@jupytergis/jupytergis-core/package.json
 
-  - name: jupytergis-lab
-    version: {{ version }}
+  - package:
+      name: jupytergis-lab
     build:
       noarch: python
       script: |
@@ -70,14 +71,14 @@ outputs:
     requirements:
       host:
         - pip
-        - python {{ python_min }}
+        - python ${{ python_min }}
         - hatchling
         - yarn
         - jupyterlab >=4.5.1
         - hatch-jupyter-builder
         - hatch-nodejs-version >=0.3.2
       run:
-        - python >={{ python_min }}
+        - python >=${{ python_min }}
         - requests
         - jupyter_ydoc >=2,<4
         - ypywidgets >=0.9.0,<0.10
@@ -86,20 +87,20 @@ outputs:
         - pydantic >=2,<3
         - jupytergis-core
         - sidecar >=0.7.0
-      run_constrained:
+      run_constraints:
         - jupyterlab >=4.5.1
-        - jupytergis-core ={{ version }}
-    test:
-      imports:
-        - jupytergis_lab.notebook.gis_document
-      commands:
-        - test -f ${PREFIX}/share/jupyter/labextensions/@jupytergis/jupytergis-lab/package.json                            # [unix]
-        - if not exist %PREFIX%\\share\\jupyter\\labextensions\\@jupytergis/jupytergis-lab\\package.json (exit 1)          # [win]
-      requires:
-        - pip
+        - jupytergis-core =${{ version }}
+    tests:
+      - python:
+          imports:
+            - jupytergis_lab.notebook.gis_document
+          pip_check: true
+      - package_contents:
+          files:
+            - share/jupyter/labextensions/@jupytergis/jupytergis-lab/package.json
 
-  - name: jupytergis-qgis
-    version: {{ version }}
+  - package:
+      name: jupytergis-qgis
     build:
       noarch: python
       script: |
@@ -108,31 +109,32 @@ outputs:
     requirements:
       host:
         - pip
-        - python {{ python_min }}
+        - python ${{ python_min }}
         - hatchling
         - yarn
         - jupyterlab >=4.5.1
         - hatch-jupyter-builder
         - hatch-nodejs-version >=0.3.2
       run:
-        - python >={{ python_min }}
+        - python >=${{ python_min }}
         - jupyter_server >=2.0.1,<3
         - jupyter_ydoc >=2,<4
         - jupytergis-core
         - jupytergis-lab
-      run_constrained:
+      run_constraints:
         - jupyterlab >=4.5.1
-        - jupytergis-lab ={{ version }}
-        - jupytergis-core ={{ version }}
-    test:
-      imports:
-        - jupytergis_qgis.qgis_loader
-      requires:
-        - pip
-        - qgis
+        - jupytergis-lab =${{ version }}
+        - jupytergis-core =${{ version }}
+    tests:
+      - python:
+          imports:
+            - jupytergis_qgis.qgis_loader
+          pip_check: true
+        requirements:
+          - qgis
 
-  - name: jupytergis-lite
-    version: {{ version }}
+  - package:
+      name: jupytergis-lite
     build:
       noarch: python
       script: |
@@ -141,25 +143,25 @@ outputs:
     requirements:
       host:
         - pip
-        - python {{ python_min }}
+        - python ${{ python_min }}
         - hatchling
       run:
-        - python >={{ python_min }}
+        - python >=${{ python_min }}
         - jupytergis-core
         - jupytergis-lab
-        - my-jupyter-shared-drive>=0.2.2
-      run_constrained:
-        - jupytergis-core ={{ version }}
-        - jupytergis-lab ={{ version }}
-    test:
-      imports:
-        - jupytergis
-      requires:
-        - pip
-        - python {{ python_min }}
+        - my-jupyter-shared-drive >=0.2.2
+      run_constraints:
+        - jupytergis-core =${{ version }}
+        - jupytergis-lab =${{ version }}
+    tests:
+      - python:
+          imports:
+            - jupytergis
+          pip_check: true
+          python_version: ${{ python_min }}.*
 
-  - name: jupytergis
-    version: {{ version }}
+  - package:
+      name: jupytergis
     build:
       noarch: python
       script: |
@@ -168,10 +170,10 @@ outputs:
     requirements:
       host:
         - pip
-        - python {{ python_min }}
+        - python ${{ python_min }}
         - hatchling
       run:
-        - python >={{ python_min }}
+        - python >=${{ python_min }}
         - jupytergis-core
         - jupytergis-lab
         - jupytergis-qgis
@@ -179,29 +181,28 @@ outputs:
         - jupyter-collaboration-ui >=2,<3
         - jupyter-docprovider >=2,<3
         - jupyter_server_ydoc >=2,<3
-      run_constrained:
+      run_constraints:
         - jupyterlab >=4.5.1
-        - jupytergis-core ={{ version }}
-        - jupytergis-lab ={{ version }}
-        - jupytergis-qgis ={{ version }}
-    test:
-      imports:
-        - jupytergis
-      requires:
-        - pip
-        - python {{ python_min }}
+        - jupytergis-core =${{ version }}
+        - jupytergis-lab =${{ version }}
+        - jupytergis-qgis =${{ version }}
+    tests:
+      - python:
+          imports:
+            - jupytergis
+          pip_check: true
+          python_version: ${{ python_min }}.*
 
 about:
-  home: https://github.com/geojupyter/jupytergis
   summary: A JupyterLab extension for collaborative GIS
   description: |
     jupytergis is a JupyterLab extension for GIS with collaborative editing support. It is designed to allow multiple people to work on the same file at the same time, and to facilitate discussion and collaboration around the GIS visualization being created.
     jupytergis has support for QGIS files, which makes it easy to import and export models from QGIS. It also has a range of features for creating and manipulating layers.
   license: BSD-3-Clause
-  license_family: BSD
   license_file: jupytergis/LICENSE
-  doc_url: https://jupytergis.readthedocs.io/en/latest
-  dev_url: https://github.com/geojupyter/jupytergis
+  homepage: https://github.com/geojupyter/jupytergis
+  documentation: https://jupytergis.readthedocs.io/en/latest
+  repository: https://github.com/geojupyter/jupytergis
 
 extra:
   recipe-maintainers:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -40,8 +40,8 @@ outputs:
         python -m pip install . -vv --no-deps --no-build-isolation --ignore-installed --no-index
     requirements:
       host:
+        - python ${{ python_min }}.*
         - pip
-        - python ==${{ python_min }}
         - hatchling
         - yarn
         - jupyterlab >=4.5.1
@@ -71,8 +71,8 @@ outputs:
         python -m pip install . -vv --no-deps --no-build-isolation --ignore-installed --no-index
     requirements:
       host:
+        - python ${{ python_min }}.*
         - pip
-        - python ==${{ python_min }}
         - hatchling
         - yarn
         - jupyterlab >=4.5.1
@@ -110,8 +110,8 @@ outputs:
         python -m pip install . -vv --no-deps --no-build-isolation --ignore-installed --no-index
     requirements:
       host:
+        - python ${{ python_min }}.*
         - pip
-        - python ==${{ python_min }}
         - hatchling
         - yarn
         - jupyterlab >=4.5.1
@@ -146,8 +146,8 @@ outputs:
         python -m pip install . -vv --no-deps --no-build-isolation --ignore-installed --no-index
     requirements:
       host:
+        - python ${{ python_min }}.*
         - pip
-        - python ==${{ python_min }}
         - hatchling
       run:
         - python >=${{ python_min }}
@@ -173,8 +173,8 @@ outputs:
         python -m pip install . -vv --no-deps --no-build-isolation --ignore-installed --no-index
     requirements:
       host:
+        - python ${{ python_min }}.*
         - pip
-        - python ==${{ python_min }}
         - hatchling
       run:
         - python >=${{ python_min }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -41,7 +41,7 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}
+        - python ==${{ python_min }}
         - hatchling
         - yarn
         - jupyterlab >=4.5.1
@@ -71,7 +71,7 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}
+        - python ==${{ python_min }}
         - hatchling
         - yarn
         - jupyterlab >=4.5.1
@@ -109,7 +109,7 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}
+        - python ==${{ python_min }}
         - hatchling
         - yarn
         - jupyterlab >=4.5.1
@@ -143,7 +143,7 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}
+        - python ==${{ python_min }}
         - hatchling
       run:
         - python >=${{ python_min }}
@@ -170,7 +170,7 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}
+        - python ==${{ python_min }}
         - hatchling
       run:
         - python >=${{ python_min }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -127,6 +127,13 @@ outputs:
         - jupyterlab >=4.5.1
         - jupytergis-lab =${{ version }}
         - jupytergis-core =${{ version }}
+        # TEMP (I hope...): QGIS depends on `qca` with no pin. In
+        # `qca ==2.3.10-1`, it switched from qt5 to qt6. The QGIS feedstock
+        # doesn't yet support qt6, so there are no versions of QGIS on
+        # conda-forge that work without the user needing to add this
+        # constraint.
+        # <https://github.com/conda-forge/qgis-feedstock/issues/596>
+        - qca <2.3.10
     tests:
       - python:
           python_version: ${{ python_min }}.*

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -54,6 +54,7 @@ outputs:
         - jupyterlab >=4.5.1
     tests:
       - python:
+          python_version: ${{ python_min }}.*
           imports:
             - jupytergis_core
           pip_check: true
@@ -92,6 +93,7 @@ outputs:
         - jupytergis-core =${{ version }}
     tests:
       - python:
+          python_version: ${{ python_min }}.*
           imports:
             - jupytergis_lab.notebook.gis_document
           pip_check: true
@@ -127,6 +129,7 @@ outputs:
         - jupytergis-core =${{ version }}
     tests:
       - python:
+          python_version: ${{ python_min }}.*
           pip_check: true
       - script:
           - python -c "import jupytergis_qgis.qgis_loader"
@@ -156,10 +159,10 @@ outputs:
         - jupytergis-lab =${{ version }}
     tests:
       - python:
+          python_version: ${{ python_min }}.*
           imports:
             - jupytergis
           pip_check: true
-          python_version: ${{ python_min }}.*
 
   - package:
       name: jupytergis
@@ -189,10 +192,10 @@ outputs:
         - jupytergis-qgis =${{ version }}
     tests:
       - python:
+          python_version: ${{ python_min }}.*
           imports:
             - jupytergis
           pip_check: true
-          python_version: ${{ python_min }}.*
 
 about:
   summary: A JupyterLab extension for collaborative GIS

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 context:
   version: "0.15.0"
   build_number: 1
-  python_min: "3.10"
+  python_min: "3.12"
 
 recipe:
   name: jupytergis-packages

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -127,11 +127,12 @@ outputs:
         - jupytergis-core =${{ version }}
     tests:
       - python:
-          imports:
-            - jupytergis_qgis.qgis_loader
           pip_check: true
+      - script:
+          - python -c "import jupytergis_qgis.qgis_loader"
         requirements:
-          - qgis
+          run:
+            - qgis
 
   - package:
       name: jupytergis-lite


### PR DESCRIPTION
Resolves #68 

For more on libqca-qt5 bug, see: https://github.com/conda-forge/qgis-feedstock/issues/596

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
