### PR TITLE
Switch sibling package pins to `pin_subpackage` (pre-releases)

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -82,18 +82,17 @@ outputs:
         - hatch-nodejs-version >=0.3.2
       run:
         - python >=${{ python_min }}
+        - ${{ pin_subpackage("jupytergis-core", exact=True) }}
         - requests
         - jupyter_ydoc >=2,<4
         - ypywidgets >=0.9.0,<0.10
         - yjs-widgets >=0.5,<0.6
         - comm >=0.1.2,<0.2
         - pydantic >=2,<3
-        - jupytergis-core
         - sidecar >=0.7.0
         - py2vega >=0.7.0
       run_constraints:
         - jupyterlab >=4.5.1
-        - jupytergis-core =${{ version }}
     tests:
       - python:
           python_version: ${{ python_min }}.*
@@ -122,14 +121,12 @@ outputs:
         - hatch-nodejs-version >=0.3.2
       run:
         - python >=${{ python_min }}
+        - ${{ pin_subpackage("jupytergis-core", exact=True) }}
+        - ${{ pin_subpackage("jupytergis-lab", exact=True) }}
         - jupyter_server >=2.0.1,<3
         - jupyter_ydoc >=2,<4
-        - jupytergis-core
-        - jupytergis-lab
       run_constraints:
         - jupyterlab >=4.5.1
-        - jupytergis-lab =${{ version }}
-        - jupytergis-core =${{ version }}
     tests:
       - python:
           python_version: ${{ python_min }}.*
@@ -154,12 +151,9 @@ outputs:
         - hatchling
       run:
         - python >=${{ python_min }}
-        - jupytergis-core
-        - jupytergis-lab
+        - ${{ pin_subpackage("jupytergis-core", exact=True) }}
+        - ${{ pin_subpackage("jupytergis-lab", exact=True) }}
         - my-jupyter-shared-drive >=0.2.2
-      run_constraints:
-        - jupytergis-core =${{ version }}
-        - jupytergis-lab =${{ version }}
     tests:
       - python:
           python_version: ${{ python_min }}.*
@@ -181,18 +175,15 @@ outputs:
         - hatchling
       run:
         - python >=${{ python_min }}
-        - jupytergis-core
-        - jupytergis-lab
-        - jupytergis-qgis
+        - ${{ pin_subpackage("jupytergis-core", exact=True) }}
+        - ${{ pin_subpackage("jupytergis-lab", exact=True) }}
+        - ${{ pin_subpackage("jupytergis-qgis", exact=True) }}
         - jupyter-collaboration >=4,<5
         - jupyter-collaboration-ui >=2,<3
         - jupyter-docprovider >=2,<3
         - jupyter_server_ydoc >=2,<3
       run_constraints:
         - jupyterlab >=4.5.1
-        - jupytergis-core =${{ version }}
-        - jupytergis-lab =${{ version }}
-        - jupytergis-qgis =${{ version }}
     tests:
       - python:
           python_version: ${{ python_min }}.*
@@ -206,10 +197,8 @@ outputs:
       noarch: generic
     requirements:
       run:
-        - jupytergis
+        - ${{ pin_subpackage("jupytergis", exact=True) }}
         - jupyter-tiler >=0.8.0
-      run_constraints:
-        - jupytergis =${{ version }}
     tests:
       - python:
           python_version: ${{ python_min }}.*

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   version: "0.16.0a4"
-  build_number: 0
+  build_number: 1
   python_min: "3.12"
 
 recipe:


### PR DESCRIPTION
This is fixed for the main branch on #72 

I'm not sure why we use the constraints method we use right now, but it seems to be causing us to not be able to install prereleases. See https://github.com/geojupyter/jupytergis/issues/1571

My theory for the cause is that if the dependency is un-pinned `jupytergis-core`, for example, this will match releases on conda-forge's `main` label (only if `main` is first in the channel priority). Then the constraint `jupytergis-core==0.16.0a4` will filter that down to 0 matches.

If we use this exact subpackage pinning, we'll match those versions as expected on the `jupytergis_prerelease` label even if it's not first in the channel priority.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
